### PR TITLE
Solr port fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ psql -h localhost -U refresh -W refresher -p 5437
 
 #### Connect to Solr
 
-Visit http://localhost:8989/solr/#/  
+Visit http://localhost:8989/solr/#/
  
+(the port is changeable via `.env`)
 
 
 ### Running the Unified Data Platform: Refresh stage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - FLATTENER_API_URL=http://192.168.0.1:7071/api/pvt/flatten/activities
       - FLATTENER_KEY_NAME=x
       - FLATTENER_KEY_VALUE=y
-      - SOLR_API_URL=http://iati-refresher-solr:${SOLR_PORT}/solr/
+      - SOLR_API_URL=http://iati-refresher-solr:8983/solr/
       - SOLR_USER=x
       - SOLR_PASSWORD=y
       - LOG_LEVEL=debug
@@ -62,8 +62,6 @@ services:
     image: solr
     ports:
       - ${SOLR_PORT}:8983
-    expose:
-      - ${SOLR_PORT}
     volumes:
       - iati-refresher-solr:/var/solr
       - ./datastore-solr-configs:/datastore-solr-configs


### PR DESCRIPTION
The ports docker option only applies to external networking. The solr app in the container still runs on it's default port. External access has port rewriting by Docker.
But internal container to container networking has to go to the port the app is listening on (and which is EXPOSEd by the container by default, so no explicit EXPOSE needed). So need to hard code default port in config var or "python src/handler.py -t solrize" can't reach Solr and it fails

The same is not true for Postgres as setting PGPORT actually changes the port the server runs on.

Also copyied and pasted comment about Solr port can be changed