### PR TITLE
build: Azurite ports, queue, Solr ver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
 
   iati-refresher-app:
@@ -49,17 +47,17 @@ services:
       - iati-refresher-dev-db:/var/lib/postgresql/data
 
   iati-refresher-azurite:
-    image: mcr.microsoft.com/azure-storage/azurite
+    image: mcr.microsoft.com/azure-storage/azurite:3.34.0
     ports:
-      - 10000:10000
-      - 10001:10001
-      - 10002:10002
-    command: azurite --blobHost 0.0.0.0 --blobPort 10000 --queueHost 0.0.0.0 --queuePort 10001 --tableHost 0.0.0.0 --tablePort 10002 --location /data --loose
+      - 13000:13000
+      - 13001:13001
+      - 13002:13002
+    command: azurite --blobHost 0.0.0.0 --blobPort 13000 --queueHost 0.0.0.0 --queuePort 13001 --tableHost 0.0.0.0 --tablePort 13002 --location /data --loose
     volumes:
       - iati-refresher-azurite:/data
 
   iati-refresher-solr:
-    image: solr
+    image: solr:9.1.1
     ports:
       - ${SOLR_PORT}:8983
     volumes:

--- a/first_time_setup.sh
+++ b/first_time_setup.sh
@@ -2,7 +2,7 @@
 
 # this command should be run after 'docker compose up' is working
 
-export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;TableEndpoint=http://localhost:10002/devstoreaccount1;"
+export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:13000/devstoreaccount1;QueueEndpoint=http://localhost:13001/devstoreaccount1;TableEndpoint=http://localhost:13002/devstoreaccount1;"
 
 echo "Running storage container create --name source"
 az storage container create --name source
@@ -15,6 +15,10 @@ az storage container create --name lake
 
 echo "Running az storage container create --name validator-adhoc"
 az storage container create --name validator-adhoc
+
+echo "Running az storage queue create --name publisher-black-flag-remove"
+az storage queue create --name publisher-black-flag-remove
+
 
 echo "Creating Solr cores for activities, transactions, and budgets"
 docker compose exec  -it  iati-refresher-solr  solr create_core -c activity_solrize -d /datastore-solr-configs/configsets/activity/conf


### PR DESCRIPTION
* Change Azurite ports so this can be run more easily alongside other instances of Azurite
* Create the storage queue used for flagging reporting orgs
* Explicitly set Solr version due to incompatibilities of Solr configs with older versions.